### PR TITLE
v0.5 - Get-MACVendor -Vendor <vendor name> now outputs as a table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.5] - 2018-05-25
+### Changed
+- Get-MACVendor -Vendor <vendor name> now returns a nice table!
+-- Table is grouped by vendor name (ex. MACs pertaining to Dell and Dell Inc. will be returned but grouped into separate tables.)
+- Readme updated to show actual output of commands
+
 ## [0.4] - 2018-05-15
 ### Added
 - New feature!  Get-MACVendor -Vendor <vendor name> to return MACs registered to given vendor

--- a/Get-MACVendor.Tests.ps1
+++ b/Get-MACVendor.Tests.ps1
@@ -27,12 +27,12 @@ Describe "Get-MACVendor -Vendor" {
     Context "Check acceptable inputs and returned results" {
         It "Allows iRobot and returns one result" {
             $results = Get-MACVendor -Vendor iRobot
-            $results | Should -Contain "1 result`r`n"
+            $results | Should -Contain "1 result"
             $results | Out-String | Should -BeLike "*50-14-79*"
         }
         It "Allows Dell and returns many results" {
             $results = Get-MACVendor -Vendor Dell
-            $results | Out-String | Should -BeLike "*results`r`n*"
+            $results | Out-String | Should -BeLike "*results*"
             $results | Out-String | Should -BeLike "*EC-F4-BB*"
         }
     }

--- a/Get-MACVendor.psm1
+++ b/Get-MACVendor.psm1
@@ -220,8 +220,20 @@ function Get-MACVendor
 				{
 					$term = "results"
 				}
-				$output = @("$num_results $term`r`n") + $output
-				return $output
+				$array_of_objects = @()
+				$num = @("$num_results $term")
+
+				foreach ($line in $output)
+				{
+					$prefix,$vendor = $line.split('(hex)')
+					$vendor = $vendor.replace('(hex)','')
+					$object = New-Object PSObject
+					Add-Member -InputObject $object -MemberType NoteProperty -Name "MAC Prefix" -Value $prefix
+					Add-Member -InputObject $object -MemberType NoteProperty -Name Vendor -Value $vendor.trim()
+					$array_of_objects += $object
+				}
+				
+				return $array_of_objects,$num
 			}
 			Catch
 			{
@@ -258,12 +270,14 @@ function Get-MACVendor
 	elseif ($vendor)
 	{		
 			# Get the MAC address(es) pertaining to a vendor
-			$addresses = Get-MACs -Vendor $vendor
+			$addresses,$num = Get-MACs -Vendor $vendor
 			
 			# If there are MACs, output them
 			if ($addresses)
 			{
 				Write-Output $addresses
+				Write-Output "`r`n"
+				Write-Output $num
 			}
 			else
 			{

--- a/Get-MACVendor.psm1
+++ b/Get-MACVendor.psm1
@@ -180,6 +180,7 @@ function Get-MACVendor
 			Catch
 			{
 				Write-Warning "MAC address was not found"
+				return false
 			}
 		}
 	}
@@ -255,12 +256,12 @@ function Get-MACVendor
 		$cleanedMAC = Clean-MAC -MAC $MAC
 		
 		# Get the vendor of the MAC address
-		$vendor = Get-Vendor -MAC $cleanedMAC
+		$returnedVendor = Get-Vendor -MAC $cleanedMAC
 		
 		# If there is a vendor, output the name
-		if ($vendor)
+		if ($returnedVendor)
 		{
-			Write-Output $vendor
+			Write-Output $returnedVendor
 		}
 		else
 		{
@@ -275,8 +276,7 @@ function Get-MACVendor
 			# If there are MACs, output them
 			if ($addresses)
 			{
-				Write-Output $addresses
-				Write-Output "`r`n"
+				$addresses | Sort-Object -Property Vendor | Format-Table -Property "MAC Prefix", Vendor -AutoSize -GroupBy Vendor
 				Write-Output $num
 			}
 			else

--- a/README.md
+++ b/README.md
@@ -9,21 +9,57 @@ This PowerShell module searches the IEEE's database of vendors/MAC addresses to 
 Import-Module ./Get-MACVendor.psm1
 ```
 
+### Return vendor assigned to MAC address
+*Input:*
 ```
+Get-MACVendor -MAC 00:12:23:45:54:32
 Get-MACVendor -MAC 00:12:23
 Get-MACVendor -MAC 00-12-23
 Get-MACVendor -MAC 001223
-Get-MACVendor -MAC 00:12:23:45:54:32
 ```
-The script will output: *Pixim*
+*Output:*
+```
+Pixim
+```
 
+### Return MAC address(es) assigned to vendor
+*Input:*
 ```
-Get-MACVendor -Vendor Dell
 Get-MACVendor -Vendor iRobot
 ```
-The script will output a list of MACs.
+*Output:*
+```
+Vendor: iRobot Corporation
 
-## Downloading/Updating the OUI list
+MAC Prefix  Vendor
+----------  ------
+50-14-79    iRobot Corporation
+
+1 result
+```
+
+*Input:*
+```
+Get-MACVendor -Vendor Sonos
+```
+*Output (shortened for space):*
+```
+Vendor: SONOS Co., Ltd.
+
+MAC Prefix  Vendor
+----------  ------
+00-04-3C    SONOS Co., Ltd.
+
+Vendor: Sonos, Inc.
+
+MAC Prefix  Vendor
+----------  ------
+5C-AA-FD    Sonos, Inc.
+00-0E-58    Sonos, Inc.
+94-9F-3E    Sonos, Inc.
+```
+
+### Downloading/Updating the OUI list
 ```
 Get-MACVendor -Action Update
 ```


### PR DESCRIPTION
## [0.5] - 2018-05-25
### Changed
- Get-MACVendor -Vendor <vendor name> now returns a nice table!
-- Table is grouped by vendor name (ex. MACs pertaining to Dell and Dell Inc. will be returned but grouped into separate tables.)
- Readme updated to show actual output of commands