### PR TITLE
Fixed build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,17 @@ language: generic
 
 matrix:
   include:
-    - os: osx
-      osx_image: xcode9.1
-      before_install:
-        - brew tap caskroom/cask
-        - brew cask install powershell
+    - os: linux
+      dist: trusty
+      sudo: required
   fast_finish: true
 
+install:
+  - curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+  - curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
+  - sudo apt-get update
+  - sudo apt-get install -y powershell
+
 script:
-  - pwsh -c 'Install-Module -Name Pester -Force -SkipPublisherCheck'
-  - pwsh -c 'Invoke-Pester -EnableExit'
+  - sudo pwsh -c 'Install-Module -Name Pester -Force -SkipPublisherCheck'
+  - sudo pwsh -c 'Invoke-Pester -EnableExit'


### PR DESCRIPTION
While Pester unit tests worked on macOS 10.12.6 w/PowerShell 6.1.0 (preview 2), they did not work in the same environment on the Travis CI build slave.  For some reason, the tables were not printed and therefore; unit tests failed.

Switching Travis CI build environment over from macOS to Ubuntu resolved the issue...somehow.

Note: No changes to the actual module were made since v0.5 was released.